### PR TITLE
Allow customize initialize timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "improv-wifi-serial-sdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "improv-wifi-serial-sdk",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@material/mwc-button": "^0.25.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "improv-wifi-serial-sdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Improv Wi-Fi Serial SDK for the browser",
   "main": "dist/serial-launch-button.js",
   "repository": "https://github.com/improv-wifi/sdk-serial-js",

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -44,9 +44,9 @@ export class ImprovSerial extends EventTarget {
 
   /**
    * Detect Improv Serial, fetch the state and return the next URL if provisioned.
-   * @returns
+   * @param timeout Timeout in ms to wait for the device to respond. Default to 1000ms.
    */
-  public async initialize(): Promise<this["info"]> {
+  public async initialize(timeout = 1000): Promise<this["info"]> {
     this.logger.log("Initializing Improv Serial");
     this._processInput();
     // To give the input processing time to start.
@@ -58,7 +58,7 @@ export class ImprovSerial extends EventTarget {
       await new Promise(async (resolve, reject) => {
         setTimeout(
           () => reject(new Error("Improv Wi-Fi Serial not detected")),
-          1000
+          timeout
         );
         await this.requestCurrentState();
         resolve(undefined);


### PR DESCRIPTION
Allow customizing the timeout to wait for a response during initialize. This is especially important when we try to fetch improv right after writing data.