### PR TITLE
Optimize bundling

### DIFF
--- a/src/serial-provision-dialog.ts
+++ b/src/serial-provision-dialog.ts
@@ -14,7 +14,7 @@ import {
   State,
 } from "./const.js";
 import { ImprovSerial, Ssid } from "./serial.js";
-import { fireEvent } from "./util.js";
+import { fireEvent } from "./util/fire-event";
 import { IsSelect } from "./components/is-select";
 
 const ERROR_ICON = "⚠️";

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -8,7 +8,8 @@ import {
   PortNotReady,
   SERIAL_PACKET_HEADER,
 } from "./const.js";
-import { hexFormatter, sleep } from "./util.js";
+import { sleep } from "./util/sleep";
+import { hexFormatter } from "./util/hex-formatter";
 
 interface FeedbackBase {
   command: ImprovSerialRPCCommand;
@@ -431,5 +432,3 @@ export class ImprovSerial extends EventTarget {
     }
   }
 }
-
-(window as any).ImprovSerial = ImprovSerial;

--- a/src/util/fire-event.ts
+++ b/src/util/fire-event.ts
@@ -18,18 +18,3 @@ export const fireEvent = <Event extends keyof HTMLElementEventMap>(
   });
   eventTarget.dispatchEvent(event);
 };
-
-export const hexFormatter = (bytes: number[] | Uint8Array) =>
-  "[" + bytes.map((value) => toHex(value) as any).join(", ") + "]";
-
-export const toHex = (value: number, size = 2) => {
-  let hex = value.toString(16).toUpperCase();
-  if (hex.startsWith("-")) {
-    return "-0x" + hex.substring(1).padStart(size, "0");
-  } else {
-    return "0x" + hex.padStart(size, "0");
-  }
-};
-
-export const sleep = (ms: number) =>
-  new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/util/hex-formatter.ts
+++ b/src/util/hex-formatter.ts
@@ -1,0 +1,4 @@
+import { toHex } from "./to-hex";
+
+export const hexFormatter = (bytes: number[] | Uint8Array) =>
+  "[" + bytes.map((value) => toHex(value) as any).join(", ") + "]";

--- a/src/util/sleep.ts
+++ b/src/util/sleep.ts
@@ -1,0 +1,2 @@
+export const sleep = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/util/to-hex.ts
+++ b/src/util/to-hex.ts
@@ -1,0 +1,8 @@
+export const toHex = (value: number, size = 2) => {
+  let hex = value.toString(16).toUpperCase();
+  if (hex.startsWith("-")) {
+    return "-0x" + hex.substring(1).padStart(size, "0");
+  } else {
+    return "0x" + hex.padStart(size, "0");
+  }
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "suppressImplicitAnyIndexErrors": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "importHelpers": true
   },
   "include": ["src/*"]
 }


### PR DESCRIPTION
- Split util.js so unused functions don't end up in bundle downstream
- Import helpers from `tslib` instead of inlining them
- Remove adding `ImprovSerial` to window. This should not have happened inside `serial.js`