### PR TITLE
Add timeout attribute to button

### DIFF
--- a/src/provision.ts
+++ b/src/provision.ts
@@ -17,18 +17,10 @@ export const startProvisioning = async (button: SerialLaunchButton) => {
     return;
   }
   let timeout: string | null ;
-<<<<<<< HEAD
   if((timeout = button.getAttribute('timeout')) == null){
-=======
-  try {
-    if((timeout = button.getAttribute('timeout')) == null){
-      timeout = '1000';
-    }
-    
-  } catch (error) {
->>>>>>> main
     timeout = '1000';
   }
+
   await port.open({ baudRate: 115200 });
 
   const el = document.createElement("improv-wifi-serial-provision-dialog");

--- a/src/provision.ts
+++ b/src/provision.ts
@@ -16,11 +16,15 @@ export const startProvisioning = async (button: SerialLaunchButton) => {
   if (!port) {
     return;
   }
-
+  let timeout: string | null ;
+  if((timeout = button.getAttribute('timeout')) == null){
+    timeout = '1000';
+  }
   await port.open({ baudRate: 115200 });
 
   const el = document.createElement("improv-wifi-serial-provision-dialog");
   el.port = port;
+  el.timeout = Number(timeout);
   el.addEventListener(
     "closed",
     () => {

--- a/src/serial-provision-dialog.ts
+++ b/src/serial-provision-dialog.ts
@@ -24,6 +24,8 @@ const OK_ICON = "🎉";
 class SerialProvisionDialog extends LitElement {
   @property() public port?: SerialPort;
 
+  @property()  public timeout=1000;
+
   public logger: Logger = console;
 
   public learnMoreUrl?: TemplateResult;
@@ -350,7 +352,7 @@ class SerialProvisionDialog extends LitElement {
     });
     client.addEventListener("error-changed", () => this.requestUpdate());
     try {
-      await client.initialize();
+      await client.initialize(this.timeout);
     } catch (err: any) {
       this._state = "ERROR";
       this._error = this.learnMoreUrl


### PR DESCRIPTION
This is a potential improvement for 
https://github.com/improv-wifi/sdk-serial-js/issues/95

(https://github.com/sle118/squeezelite-esp32/issues/187  )

Our firmware has an init sequence that is ~4 to 5 seconds before reaching a point where improv can start interacting. The default timeout of 1000ms was insufficient and caused the wifi button to work inconsistently. Users would need to click a couple of times before improv was able to detect a response from the firmware.

This change allows speficying a different timeout when declaring the button in the html document like this:
`<improv-wifi-serial-launch-button id="button_improv_serial" learnMoreUrl="https://www.esphome.io/components/improv_serial.html" timeout="5000"></improv-wifi-serial-launch-button>`