### PR TITLE
Simplify close command

### DIFF
--- a/src/serial.ts
+++ b/src/serial.ts
@@ -89,10 +89,10 @@ export class ImprovSerial extends EventTarget {
   }
 
   public async close() {
+    if (!this._reader) {
+      return;
+    }
     await new Promise((resolve) => {
-      if (!this._reader) {
-        resolve(undefined);
-      }
       this._reader!.cancel();
       this.addEventListener("disconnect", resolve, { once: true });
     });


### PR DESCRIPTION
Skip creating a promise to instantly resolve if no reader object available.