### PR TITLE
Fix UTF-8 decoding of RPC results

### DIFF
--- a/src/serial.ts
+++ b/src/serial.ts
@@ -395,11 +395,10 @@ export class ImprovSerial extends EventTarget {
       // Chop off rpc command and checksum
       const result: string[] = [];
       const totalLength = data[1];
+      const decoder = new TextDecoder("utf-8");
       let idx = 2;
       while (idx < 2 + totalLength) {
-        result.push(
-          String.fromCodePoint(...data.slice(idx + 1, idx + data[idx] + 1))
-        );
+        result.push(decoder.decode(new Uint8Array(data.slice(idx + 1, idx + data[idx] + 1))));
         idx += data[idx] + 1;
       }
       if ("receivedData" in this._rpcFeedback) {


### PR DESCRIPTION
This library incorrectly treated bytes as code points when decoding serial communications, resulting in UTF-8 looking like the following. This PR replaces this with the proper `TextDecoder`.

![](https://mastodon-data.content.as207960.net/media_attachments/files/115/086/383/611/036/217/original/88202e47e1638415.png)
