### PR TITLE
Add STOPPED current state

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -24,6 +24,7 @@ export enum ImprovSerialMessageType {
 }
 
 export enum ImprovSerialCurrentState {
+  STOPPED = 0x00, // Provisioning unavailable (e.g. Wi-Fi disabled on the device)
   READY = 0x02, // Authorized
   PROVISIONING = 0x03,
   PROVISIONED = 0x04,


### PR DESCRIPTION
## What

Add `STOPPED = 0x00` to the `ImprovSerialCurrentState` enum.

## Why

A device reports the **stopped** state when Improv provisioning is currently
unavailable — for example, when Wi-Fi is disabled because the device is running
on Ethernet. The value already exists in the device-side Improv state enum
(`improv-wifi/sdk-cpp`, `STATE_STOPPED = 0x00`), so devices can already emit it;
it was just missing from this serial client's enum, so consumers had no clean
way to recognize it.

With this value present, a client can detect that the connected device is
stopped and surface an appropriate message instead of presenting the Wi-Fi
provisioning form.

## Notes

- The client already stores the raw state byte (`serial.ts`: `this.state = data[0]`),
  so no logic change is needed — this only exposes the value through the enum.
- Pairs with an ESPHome firmware change (which reports `STOPPED` over serial when
  Wi-Fi is disabled) and a follow-up `esp-web-tools` change that renders a message
  for the stopped state.
- See also esphome/esphome#16904