### PR TITLE
Add network-state reporting and harden provisioning RPCs

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -58,6 +58,16 @@ export const enum ImprovSerialRPCCommand {
   REQUEST_WIFI_NETWORKS = 0x04,
   HOSTNAME = 0x05,
   DEVICE_NAME = 0x06,
+  REQUEST_NETWORK_STATE = 0x07, // Connectivity + interface inventory
+}
+
+// Bitfield in element [0] of a REQUEST_NETWORK_STATE response.
+export const enum ImprovNetworkFlag {
+  IS_ONLINE = 1 << 0, // online via any interface
+  SUPPORTS_WIFI = 1 << 1, // present, possibly disabled
+  SUPPORTS_ETHERNET = 1 << 2,
+  SUPPORTS_THREAD = 1 << 3,
+  SUPPORTS_MODEM = 1 << 4,
 }
 
 export class PortNotReady extends Error {

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -1,5 +1,6 @@
 import {
   ERROR_MSGS,
+  ImprovNetworkFlag,
   ImprovSerialCurrentState,
   ImprovSerialErrorState,
   ImprovSerialMessageType,
@@ -28,6 +29,16 @@ export interface Ssid {
   name: string;
   rssi: number;
   secured: boolean;
+}
+
+export interface NetworkState {
+  online: boolean;
+  supportsWifi: boolean;
+  supportsEthernet: boolean;
+  supportsThread: boolean;
+  supportsModem: boolean;
+  // Reachable device URL(s), same as returned after provisioning. Empty offline.
+  urls: string[];
 }
 
 const sortSsids = (ssids: Ssid[]): Ssid[] =>
@@ -392,6 +403,34 @@ export class ImprovSerial extends EventTarget {
       this.info.name = response[0];
     }
     return response[0];
+  }
+
+  /**
+   * Request the device's network connectivity and supported interfaces.
+   *
+   * This is independent of the Wi-Fi provisioning state: a device already
+   * online over Ethernet reports that here without Wi-Fi provisioning. The
+   * first response string is the network flags as a decimal-encoded byte, and
+   * when online the reachable device URL(s) follow.
+   *
+   * This command is optional. Devices that do not implement it respond with
+   * UNKNOWN_RPC_COMMAND, so this rejects with that error for such devices.
+   */
+  public async requestNetworkState(timeout?: number): Promise<NetworkState> {
+    const response = await this._sendRPCWithResponse(
+      ImprovSerialRPCCommand.REQUEST_NETWORK_STATE,
+      [],
+      timeout,
+    );
+    const flags = parseInt(response[0]);
+    return {
+      online: (flags & ImprovNetworkFlag.IS_ONLINE) !== 0,
+      supportsWifi: (flags & ImprovNetworkFlag.SUPPORTS_WIFI) !== 0,
+      supportsEthernet: (flags & ImprovNetworkFlag.SUPPORTS_ETHERNET) !== 0,
+      supportsThread: (flags & ImprovNetworkFlag.SUPPORTS_THREAD) !== 0,
+      supportsModem: (flags & ImprovNetworkFlag.SUPPORTS_MODEM) !== 0,
+      urls: response.slice(1),
+    };
   }
 
   private _sendRPC(command: ImprovSerialRPCCommand, data: number[]) {

--- a/test/serial.test.ts
+++ b/test/serial.test.ts
@@ -170,6 +170,21 @@ describe("ImprovSerial RPC serialization", () => {
     expect(client._rpcFeedback).toBeUndefined();
   });
 
+  it("decodes the network state flags and URLs", async () => {
+    const client: any = newClient();
+    // Spec example: flags 7 (online + Wi-Fi + Ethernet) followed by the URL.
+    fakeDevice(client, { result: ["7", "http://192.168.1.10"] });
+
+    await expect(client.requestNetworkState()).resolves.toEqual({
+      online: true,
+      supportsWifi: true,
+      supportsEthernet: true,
+      supportsThread: false,
+      supportsModem: false,
+      urls: ["http://192.168.1.10"],
+    });
+  });
+
   it("catches a state change fired synchronously on send", async () => {
     const client: any = newClient();
     // An instant device that answers the moment the request goes out: the


### PR DESCRIPTION
## Summary

Adds new `REQUEST_NETWORK_STATE = 0x07` command and `ImprovNetworkFlag` bitfield (`IS_ONLINE`, `SUPPORTS_WIFI`, `SUPPORTS_ETHERNET`, `SUPPORTS_THREAD`, `SUPPORTS_MODEM`).

## Related

- Spec: improv-wifi/website#66 — documents the `Get Network State` (`0x07`) RPC in `src/serial.md` (per review, so the spec leads the SDKs)
- Device SDK: improv-wifi/sdk-cpp#34