### PR TITLE
Re-send state request every second during initialize

### DIFF
--- a/src/serial.ts
+++ b/src/serial.ts
@@ -71,19 +71,29 @@ export class ImprovSerial extends EventTarget {
     if (this._reader === undefined) {
       throw new PortNotReady();
     }
+    // The device might still be booting (e.g. right after being flashed) and
+    // miss our request, so re-send it every second until it responds.
+    let retryInterval: ReturnType<typeof setInterval> | undefined;
     try {
       await new Promise(async (resolve, reject) => {
         setTimeout(
           () => reject(new Error("Improv Wi-Fi Serial not detected")),
           timeout
         );
+        retryInterval = setInterval(
+          () => this._sendRPC(ImprovSerialRPCCommand.REQUEST_CURRENT_STATE, []),
+          1000
+        );
         await this.requestCurrentState();
         resolve(undefined);
       });
+      clearInterval(retryInterval);
       await this.requestInfo();
     } catch (err) {
       await this.close();
       throw err;
+    } finally {
+      clearInterval(retryInterval);
     }
     return this.info!;
   }


### PR DESCRIPTION
## Problem

`initialize()` sends exactly one `RequestCurrentState` packet (about 1 second after the port is opened) and then just waits for a reply until the detection timeout expires. Right after flashing, the device is often still booting at that moment — the bootloader is verifying the new image, the filesystem is being initialized, or the serial driver isn't installed yet — so the single packet is lost and never re-sent. Detection then fails even though the device would have responded moments later, and the user has to reset the device and reconnect before Wi-Fi provisioning works.

This is the main cause of the "device needs another reset after flashing before Improv responds" reports with ESP Web Tools, which passes a 10 second timeout for fresh installs (`new_install_improv_wait_time`) — but that timeout only ever covered a single request.

## Solution

While waiting for the current-state response in `initialize()`, re-send the raw `RequestCurrentState` packet every second until the device responds or the detection timeout expires. Detection now succeeds as soon as the device finishes booting, which is what the fresh-install wait time was always meant to allow.

Details:
- Only the raw packet is re-sent; the pending RPC feedback from the original `requestCurrentState()` call stays armed, so a response to any retry resolves it normally.
- The retry interval is cleared as soon as the state response arrives (before `requestInfo()` runs, so a stray retry can't collide with the device-info RPC) and also on the error path.
- Devices that are already running respond to the first packet within a second, so no retry fires and existing behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163vvTpZcAfCKmKmMCZEGib

---
_Generated by [Claude Code](https://claude.ai/code/session_0163vvTpZcAfCKmKmMCZEGib)_