### PR TITLE
Give the device 10s to respond during Improv detection

### DIFF
--- a/src/serial-provision-dialog.ts
+++ b/src/serial-provision-dialog.ts
@@ -501,7 +501,7 @@ class SerialProvisionDialog extends LitElement {
     });
     client.addEventListener("error-changed", () => this.requestUpdate());
     try {
-      await client.initialize();
+      await client.initialize(10000);
     } catch (err: any) {
       this._state = "ERROR";
       this._error = this.learnMoreUrl


### PR DESCRIPTION
The provision dialog called `initialize()` without arguments, so it used the 1000ms default timeout.

`initialize()` sleeps 1000ms to let the read loop start, then races a 1000ms rejection timer against the 1000ms retry interval that re-sends the state request. The upshot is that the retry added in #142 never got a chance to fire from this dialog — a device that was still booting (e.g. right after being flashed) would be reported as not supporting Improv.

This passes an explicit 10s timeout, matching what esp-web-tools already does, so the client-side retry has room to actually retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HKKQv6JkVjUK4Q5tMVxgA