### PR TITLE
Handle the STOPPED state in the provision dialog

### DIFF
--- a/src/serial-provision-dialog.ts
+++ b/src/serial-provision-dialog.ts
@@ -184,6 +184,12 @@ class SerialProvisionDialog extends LitElement {
         `An error occurred. ${this._error}`,
       );
       actions = this._renderCloseAction();
+    } else if (this._client!.state === ImprovSerialCurrentState.STOPPED) {
+      content = this._renderMessage(
+        ERROR_ICON,
+        "The connected device has Wi-Fi turned off, so it can't be configured right now. Enable the device's Wi-Fi, then try again.",
+      );
+      actions = this._renderCloseAction();
     } else if (this._client!.state === ImprovSerialCurrentState.READY) {
       if (this._busy) {
         content = this._renderProgress("Provisioning");


### PR DESCRIPTION
`ImprovSerialCurrentState.STOPPED` (`0x00`) means provisioning is unavailable, e.g. because Wi-Fi is turned off on the device.

The dialog only handled `READY`/`PROVISIONING`/`PROVISIONED`, so a stopped device fell through to the catch-all branch and showed `Unexpected state: IMPROV-STATE - 0`. That reads like a bug in the SDK rather than something the user can act on.

This shows the same actionable message esp-web-tools already shows for this state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HKKQv6JkVjUK4Q5tMVxgA