### PR TITLE
Add get/set hostname and device name methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,17 @@ await improv.provision(
   30000  // Optional: Timeout in ms
 );
 ```
+
+The hostname and device name can be read and written while the device is authorized. Each method takes an optional timeout in ms as its last argument, and the setters return the value as it was applied by the device.
+
+```ts
+const hostname = await improv.getHostname();
+await improv.setHostname("my-device");
+
+const deviceName = await improv.getDeviceName();
+await improv.setDeviceName("My Device");
+```
+
+Hostnames need to conform to [RFC 1123](https://datatracker.ietf.org/doc/html/rfc1123): letters, numbers and hyphens, up to 255 characters. `setHostname` rejects with `BAD_HOSTNAME` if the device does not accept the hostname.
+
+If you set both, set the device name first, as it can change the default hostname.

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -203,6 +203,71 @@ export class ImprovSerial extends EventTarget {
     return ssids;
   }
 
+  /**
+   * Get the current hostname of the device.
+   */
+  public async getHostname(timeout?: number): Promise<string> {
+    const response = await this._sendRPCWithResponse(
+      ImprovSerialRPCCommand.HOSTNAME,
+      [],
+      timeout,
+    );
+    return response[0];
+  }
+
+  /**
+   * Set the hostname of the device. Returns the hostname as set by the device.
+   *
+   * Hostnames need to conform to RFC 1123: letters, numbers and hyphens, up to
+   * 255 characters. The device rejects other hostnames with a BAD_HOSTNAME error.
+   */
+  public async setHostname(
+    hostname: string,
+    timeout?: number,
+  ): Promise<string> {
+    const encoder = new TextEncoder();
+    const response = await this._sendRPCWithResponse(
+      ImprovSerialRPCCommand.HOSTNAME,
+      [...encoder.encode(hostname)],
+      timeout,
+    );
+    return response[0];
+  }
+
+  /**
+   * Get the current device name. This is the same value as `info.name`.
+   */
+  public async getDeviceName(timeout?: number): Promise<string> {
+    const response = await this._sendRPCWithResponse(
+      ImprovSerialRPCCommand.DEVICE_NAME,
+      [],
+      timeout,
+    );
+    return response[0];
+  }
+
+  /**
+   * Set the device name. Returns the device name as set by the device.
+   *
+   * When setting both the device name and the hostname, set the device name
+   * first, as it can change the default hostname.
+   */
+  public async setDeviceName(
+    deviceName: string,
+    timeout?: number,
+  ): Promise<string> {
+    const encoder = new TextEncoder();
+    const response = await this._sendRPCWithResponse(
+      ImprovSerialRPCCommand.DEVICE_NAME,
+      [...encoder.encode(deviceName)],
+      timeout,
+    );
+    if (this.info) {
+      this.info.name = response[0];
+    }
+    return response[0];
+  }
+
   private _sendRPC(command: ImprovSerialRPCCommand, data: number[]) {
     this.writePacketToStream(ImprovSerialMessageType.RPC, [
       command,


### PR DESCRIPTION
The `HOSTNAME` (`0x05`) and `DEVICE_NAME` (`0x06`) RPC commands and the `BAD_HOSTNAME` error were added to `const.ts` in #141, but nothing ever sent those commands — `ImprovSerial` only exposed `provision()`, `scan()`, `requestInfo()` and `requestCurrentState()`. So the constants were dead code and the feature was unusable from a client. This adds the four methods that use them:

```ts
const hostname = await improv.getHostname();
await improv.setHostname("my-device");

const deviceName = await improv.getDeviceName();
await improv.setDeviceName("My Device");
```

Per the spec, sending the command with no data reads the value and sending it with data writes it; both return the value as applied by the device, which is what the setters resolve with. Setting the device name also updates the cached `info.name`, since the device info RPC reports the same value and would otherwise go stale.

I verified the generated frames byte for byte against the serial spec — command byte, data length, payload and checksum, including the zero-length data for the getters — and checked they satisfy the length invariant the C++ SDK asserts when parsing (`data_length == length - 2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HKKQv6JkVjUK4Q5tMVxgA