### PR TITLE
Settle the state request promise when not provisioned

### DIFF
--- a/src/serial.ts
+++ b/src/serial.ts
@@ -145,11 +145,10 @@ export class ImprovSerial extends EventTarget {
 
     // Only if we are provisioned will we get an rpc result
     if (this.state !== ImprovSerialCurrentState.PROVISIONED) {
-      // Nothing will ever settle rpcResult, so resolve it before dropping the
-      // feedback, otherwise it stays pending forever.
-      const feedback = this._rpcFeedback as FeedbackSinglePacket | undefined;
+      // The device won't send an RPC result, so settle the promise ourselves.
+      // Otherwise it stays pending forever once we drop the feedback.
+      this._rpcFeedback?.resolve([]);
       this._rpcFeedback = undefined;
-      feedback?.resolve([]);
       return;
     }
 

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -145,7 +145,11 @@ export class ImprovSerial extends EventTarget {
 
     // Only if we are provisioned will we get an rpc result
     if (this.state !== ImprovSerialCurrentState.PROVISIONED) {
+      // Nothing will ever settle rpcResult, so resolve it before dropping the
+      // feedback, otherwise it stays pending forever.
+      const feedback = this._rpcFeedback as FeedbackSinglePacket | undefined;
       this._rpcFeedback = undefined;
+      feedback?.resolve([]);
       return;
     }
 


### PR DESCRIPTION
When the device is not provisioned it does not send an RPC result for `REQUEST_CURRENT_STATE`. `requestCurrentState()` handled that by dropping `_rpcFeedback` and returning early — but the promise that `_sendRPCWithResponse()` handed back was then left pending forever, because clearing the feedback also drops the only reference to its `resolve`/`reject`.

Nothing awaits it on that path today, so this is not a user-visible bug, but it is a trap for anyone who later awaits the result. Resolve it with an empty result before dropping the feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HKKQv6JkVjUK4Q5tMVxgA