### PR TITLE
Use system sans-serif font in provision dialog

### DIFF
--- a/src/serial-provision-dialog.ts
+++ b/src/serial-provision-dialog.ts
@@ -557,6 +557,9 @@ class SerialProvisionDialog extends LitElement {
       --md-dialog-container-max-block-size: none !important;
       --md-sys-color-primary: var(--improv-primary-color, #03a9f4);
       --md-sys-color-on-primary: var(--improv-on-primary-color, #fff);
+      --md-ref-typeface-brand: system-ui, sans-serif;
+      --md-ref-typeface-plain: system-ui, sans-serif;
+      font-family: system-ui, sans-serif;
     }
 
     md-dialog {


### PR DESCRIPTION
The provision dialog was rendering in a serif font. Material Web components default to Roboto and fall back to a serif font when Roboto isn't loaded.

This sets the Material typeface tokens (`--md-ref-typeface-brand` / `--md-ref-typeface-plain`) and `font-family` on `:host` to the system default sans-serif, so the dialog renders consistently regardless of whether Roboto is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)