### PR TITLE
Set placeholder version to 0.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "improv-wifi-serial-sdk",
-  "version": "2.5.0",
+  "version": "0.0.0",
   "description": "Improv Wi-Fi Serial SDK for the browser",
   "main": "dist/serial-launch-button.js",
   "repository": "https://github.com/improv-wifi/sdk-serial-js",


### PR DESCRIPTION
The published version is derived from the GitHub release tag by the `npm publish` workflow (`npm version --no-git-tag-version "$GITHUB_REF_NAME"`), so the committed `package.json` version is just a placeholder. Set it to `0.0.0` to reflect that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)