### PR TITLE
Fix npm publish on Node 24

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -14,10 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
-      - name: Update npm to latest
-        run: npm install -g npm@latest
       - run: npm ci
       - name: Set version from release tag
         run: npm version --no-git-tag-version "$GITHUB_REF_NAME"


### PR DESCRIPTION
The 2.6.0 release failed to publish. The `Node.js Package` workflow runs on Node 20 and then runs `npm install -g npm@latest`. The latest npm (12.x) now requires Node >=22, so the upgrade aborts with `EBADENGINE` and the package never publishes:

```
npm error engine Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

This bumps the workflow to Node 24 and drops the redundant `npm install -g npm@latest` step (Node 24 already bundles a recent npm), removing this class of breakage.

After merge, the 2.6.0 GitHub release needs to be re-published (or the workflow re-run) since nothing made it to npm (latest is still 2.5.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)