### PR TITLE
Upgrade GitHub Actions and CI Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 24
       - run: npm ci
       - run: script/build
       - run: npm exec -- prettier --check src

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -11,8 +11,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,6 +9,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to the 2.6.0 publish fix. Brings the remaining workflow actions and CI Node version up to date.

- `actions/checkout` v3/v4 → **v7**
- `actions/setup-node` v3/v4 → **v6**
- `release-drafter/release-drafter` v5 → **v7**
- CI `node-version` **16 → 24** (Node 16 is end-of-life; now matches the publish workflow)

The checkout/setup-node bumps clear the "Node.js 20 is deprecated" runtime warnings that showed up in the last publish run. Build verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)