### PR TITLE
Remove the warm-up sleep from initialize()

### DIFF
--- a/src/serial.ts
+++ b/src/serial.ts
@@ -8,7 +8,6 @@ import {
   PortNotReady,
   SERIAL_PACKET_HEADER,
 } from "./const.js";
-import { sleep } from "./util/sleep";
 import { hexFormatter } from "./util/hex-formatter";
 
 interface FeedbackBase {
@@ -72,9 +71,9 @@ export class ImprovSerial extends EventTarget {
    */
   public async initialize(timeout = 1000): Promise<this["info"]> {
     this.logger.log("Initializing Improv Serial");
+    // Grabs the reader before its first await, so it is set (or failed to be
+    // set) by the time this returns.
     this._processInput();
-    // To give the input processing time to start.
-    await sleep(1000);
     if (this._reader === undefined) {
       throw new PortNotReady();
     }


### PR DESCRIPTION
Detecting Improv currently costs a fixed extra second, for no benefit.

`initialize()` opens with:

```js
this._processInput();
// To give the input processing time to start.
await sleep(1000);
if (this._reader === undefined) {
  throw new PortNotReady();
}
```

The sleep is there to make the `PortNotReady` check meaningful, but it is not needed for that. `_processInput()` assigns `this._reader = this.port.readable!.getReader()` as its first statement, before its first `await`, so by the time `this._processInput()` returns its promise the reader is already set — or `getReader()` threw, in which case it never will be. The check is settled either way, immediately.

The other thing a warm-up could plausibly buy — giving a device that is still booting time to come up — is already what the retry loop directly below it does, re-sending `REQUEST_CURRENT_STATE` every second until the timeout.

So the sleep only delays detection by a second. Removing it means the first request goes out at t=0 instead of t=1s, which also leaves room for the retry to actually fire when a caller passes a short timeout. esp-web-tools passes 1000ms on a normal dialog open, so today the retry interval (first tick at 1s) races the reject timer (also 1s) and the device effectively gets a single request — with this change, a 1500ms timeout gets a request at t=0 and a real retry at t=1s.

This showed up as devices intermittently failing to be detected as Improv-capable after a page reload: the device is still streaming Wi-Fi scan results from before the reload, its answer to our one request lands late, and we give up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ccoEj3YjfBXZS86vVB68V