### PR TITLE
Show device info when a provisioned device connects

### DIFF
--- a/src/serial-provision-dialog.ts
+++ b/src/serial-provision-dialog.ts
@@ -176,7 +176,7 @@ class SerialProvisionDialog extends LitElement {
     let content: TemplateResult;
     let actions: TemplateResult | undefined;
 
-    if (this._state === "CONNECTING") {
+    if (this._state === "CONNECTING" || !this._client) {
       content = this._renderProgress("Connecting");
     } else if (this._state === "ERROR") {
       content = this._renderMessage(
@@ -206,10 +206,13 @@ class SerialProvisionDialog extends LitElement {
     } else if (this._client!.state === ImprovSerialCurrentState.PROVISIONING) {
       content = this._renderProgress("Provisioning");
     } else if (this._client!.state === ImprovSerialCurrentState.PROVISIONED) {
-      content = html` <div class="center">
-        <div class="icon">${OK_ICON}</div>
-        Provisioned!
-      </div>`;
+      content = html`
+        ${this._client?.info ? this._renderDeviceInfo() : nothing}
+        <div class="center">
+          <div class="icon">${OK_ICON}</div>
+          Provisioned!
+        </div>
+      `;
       actions =
         this._client!.nextUrl === undefined
           ? this._renderCloseAction()


### PR DESCRIPTION
## Summary

When connecting a device that is **already provisioned**, the dialog jumped straight to a bare "Provisioned!" message and never showed the device info box (name, firmware, version, chip, OS) that is displayed above the configure form in the `READY` state.

This renders that same info block in the `PROVISIONED` state, reusing the existing `_renderDeviceInfo()` helper with the same `this._client?.info` guard used in `_renderImprovReady()`.

While testing this, a pre-existing render crash surfaced:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'state')
    at SerialProvisionDialog.render
```

The `state-changed` listener is registered before `this._client` is assigned, so a device reporting its state during `initialize()` could trigger a render while `_client` was still `undefined`, hitting `this._client!.state`. Guarding the connecting branch on `_client` being present fixes it — the spinner shows until the client is ready.

## Testing

Verified manually: connecting an already-provisioned device now shows the device info box above "Provisioned!", and the console error no longer appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zwMkRVTYQ8LysikVXNEya