### PR TITLE
Signal unavailable Wi-Fi scanning via subscribeSSIDs(null)

### DIFF
--- a/src/serial-provision-dialog.ts
+++ b/src/serial-provision-dialog.ts
@@ -434,19 +434,22 @@ class SerialProvisionDialog extends LitElement {
       return;
     }
     if (shouldScan) {
-      this._unsubSSIDs = this._client!.subscribeSSIDs((ssids) => {
-        if (this._ssids === undefined) {
+      this._unsubSSIDs = this._client!.subscribeSSIDs((networks) => {
+        if (networks === null) {
+          // Scanning isn't available; fall back to manual network entry.
+          this._selectedSsid = null;
+        } else if (this._ssids == null) {
           // First result: default to the strongest (first alphabetical) one.
-          this._selectedSsid = ssids.length ? ssids[0].name : null;
+          this._selectedSsid = networks.length ? networks[0].name : null;
         } else if (
           this._selectedSsid !== null &&
-          !ssids.some((s) => s.name === this._selectedSsid)
+          !networks.some((s) => s.name === this._selectedSsid)
         ) {
           // The selected network is no longer available. Keep "Join other"
           // (null) selections as-is.
-          this._selectedSsid = ssids.length ? ssids[0].name : null;
+          this._selectedSsid = networks.length ? networks[0].name : null;
         }
-        this._ssids = ssids;
+        this._ssids = networks;
       });
     } else {
       this._stopScanning();
@@ -534,18 +537,7 @@ class SerialProvisionDialog extends LitElement {
       this._state = "IMPROV-STATE";
       this.requestUpdate();
     });
-    client.addEventListener("error-changed", () => {
-      // If scanning fails before we have any networks, the device likely
-      // doesn't support it. Fall back to manual network entry.
-      if (
-        this._ssids === undefined &&
-        client.error !== ImprovSerialErrorState.NO_ERROR
-      ) {
-        this._ssids = null;
-        this._selectedSsid = null;
-      }
-      this.requestUpdate();
-    });
+    client.addEventListener("error-changed", () => this.requestUpdate());
     try {
       await client.initialize(10000);
     } catch (err: any) {

--- a/src/serial-provision-dialog.ts
+++ b/src/serial-provision-dialog.ts
@@ -445,8 +445,10 @@ class SerialProvisionDialog extends LitElement {
           this._selectedSsid !== null &&
           !networks.some((s) => s.name === this._selectedSsid)
         ) {
-          // The selected network is no longer available. Keep "Join other"
-          // (null) selections as-is.
+          // A merged scan never drops networks, but the selection persists
+          // across scan restarts (after a failed provision, or reopening to
+          // change Wi-Fi), and the first fresh scan may not include it yet.
+          // Re-default when that happens; keep "Join other" (null) as-is.
           this._selectedSsid = networks.length ? networks[0].name : null;
         }
         this._ssids = networks;

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -50,6 +50,13 @@ const mergeSsids = (previous: Ssid[], latest: Ssid[]): Ssid[] => {
 /** Delay between Wi-Fi scans while subscribed. */
 const SCAN_INTERVAL = 3000;
 
+/**
+ * Timeout for each scan while subscribed. Generous compared to a real scan
+ * (a few seconds) so it only trips when the device stops responding, turning a
+ * silent hang into an error the subscriber is told about.
+ */
+const SCAN_TIMEOUT = 30000;
+
 /** Whether two (alphabetically sorted) SSID lists differ in any value. */
 const ssidsChanged = (a: Ssid[], b: Ssid[]): boolean => {
   if (a.length !== b.length) {
@@ -222,10 +229,11 @@ export class ImprovSerial extends EventTarget {
     this.nextUrl = response[0];
   }
 
-  public async scan(): Promise<Ssid[]> {
+  public async scan(timeout?: number): Promise<Ssid[]> {
     const results = await this._sendRPCWithMultipleResponses(
       ImprovSerialRPCCommand.REQUEST_WIFI_NETWORKS,
       [],
+      timeout,
     );
     const ssids = results.map(([name, rssi, secured]) => ({
       name,
@@ -244,13 +252,16 @@ export class ImprovSerial extends EventTarget {
    * immediately disappear. `onChange` is only called when a value in the list
    * actually changes.
    *
-   * Scanning stops on the first error (e.g. when the device doesn't support it)
-   * or when the returned function is called. That function resolves once the
-   * in-flight scan has settled, so it can be awaited before sending another RPC
-   * command (such as provisioning).
+   * Scanning stops on the first error or when the returned function is called.
+   * If the first scan fails (e.g. the device doesn't support scanning, or stops
+   * responding), `onChange` is called once with `null` to signal that networks
+   * are unavailable.
+   *
+   * The returned function resolves once the in-flight scan has settled, so it
+   * can be awaited before sending another RPC command (such as provisioning).
    */
   public subscribeSSIDs(
-    onChange: (ssids: Ssid[]) => void,
+    onChange: (ssids: Ssid[] | null) => void,
   ): () => Promise<void> {
     let active = true;
     let current: Ssid[] | undefined;
@@ -260,9 +271,15 @@ export class ImprovSerial extends EventTarget {
       while (active) {
         let ssids: Ssid[];
         try {
-          ssids = await this.scan();
+          ssids = await this.scan(SCAN_TIMEOUT);
         } catch (err) {
           this.logger.error("Error while scanning for Wi-Fi networks", err);
+          // Only signal unavailability if we never got a result. Once we have
+          // networks, scanning is clearly supported, so keep the last list on a
+          // transient failure. Either way, stop scanning.
+          if (active && current === undefined) {
+            onChange(null);
+          }
           break;
         }
         if (!active) {


### PR DESCRIPTION
## Summary

Follow-up to #156. `subscribeSSIDs` previously stopped **silently** on the first scan error, giving consumers no signal — a device that doesn't support scanning (or stops responding) left the provisioning dialog spinning on "Searching for networks" forever.

- The `onChange` callback now receives **`null`** when the first scan fails (unsupported device, or a hang caught by the new timeout), then scanning stops.
- `scan()` accepts an optional timeout; the subscription scans with a **30s timeout**, so a silent hang becomes a rejection → `null` instead of hanging indefinitely. 30s is well above a real scan (a few seconds), so it won't false-trip on slow-but-working devices.
- A failure *after* a successful scan keeps the last list (scanning clearly works — it hiccuped).
- The dialog falls back to manual entry on `null`, replacing the `error-changed` workaround that only caught *device-reported* errors.

## Note on semver

This changes the `subscribeSSIDs` callback type from `(ssids: Ssid[]) => void` to `(ssids: Ssid[] | null) => void`. Technically a breaking type change, but `subscribeSSIDs` shipped only in 2.7.0, so this goes out as a patch (2.7.1).

## Test plan

- `script/build` (tsc + rollup) passes
- `prettier --check src` passes
- Manual device verification of the unsupported-scan / hang fallback still recommended

🤖 Generated with [Claude Code](https://claude.com/claude-code)