### PR TITLE
Read the Wi-Fi form before it is replaced by the progress view

### DIFF
--- a/src/serial-provision-dialog.ts
+++ b/src/serial-provision-dialog.ts
@@ -468,6 +468,13 @@ class SerialProvisionDialog extends LitElement {
   }
 
   private async _provision() {
+    // Read the form before setting `_busy`: that swaps the form for a progress
+    // view, and the render happens during any await below — after which the
+    // fields no longer exist and we'd provision with an empty password.
+    const ssid =
+      this._selectedSsid === null ? this._inputSSID.value : this._selectedSsid;
+    const password = this._inputPassword?.value || "";
+
     this._busy = true;
     // Wait for any in-flight scan to settle before provisioning so we don't
     // have two RPC commands in flight at once. Marking busy above already tells
@@ -475,11 +482,13 @@ class SerialProvisionDialog extends LitElement {
     await this._stopScanning();
     try {
       await this._client!.provision(
-        this._selectedSsid === null
-          ? this._inputSSID.value
-          : this._selectedSsid,
-        this._inputPassword?.value || "",
-        30000, // Timeout in 30 seconds
+        ssid,
+        password,
+        // Devices try to connect for ~30s before reporting failure. Our
+        // timeout must comfortably exceed that: it's only a safety net, and if
+        // it fires first the device's late failure packet rejects the *next*
+        // RPC we send (the resumed network scan) instead of this one.
+        45000,
       );
       // Success: leave the change-Wi-Fi form and show the provisioned screen.
       this._reprovision = false;


### PR DESCRIPTION
Provisioning could silently send an **empty password**. `_provision` sets `_busy = true` — which swaps the form for the "Provisioning" progress view — and then `await this._stopScanning()` before reading the SSID and password fields out of the DOM. Lit renders on a microtask, so the re-render runs during that await; by the time the `@query` getters are read the fields no longer exist. The password read became `undefined?.value || ""` and we provisioned with an empty password (the manual-SSID path would even throw on `_inputSSID.value`). Fix: read the form first, then go busy.

Caught on real hardware via a packet log in esp-web-tools, which inherited the same sequence: the `SEND_WIFI_SETTINGS` write showed the correct SSID followed by a `0x00` password length. Fixed there in esphome/esp-web-tools#712.

This also raises the provision timeout from 30s to 45s. Devices try to connect for ~30s before reporting failure, so a 30s timeout races the device's own verdict — and when we lose, the late `UNABLE_TO_CONNECT` packet rejects whatever RPC is pending *next* (the resumed network scan, since `_setError` can't attribute error packets to a command), killing the fresh scan subscription on its first scan and dropping the user to manual entry. With 45s the device's verdict comfortably arrives first and rejects the right RPC, with a better error message than "Timeout" to boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ccoEj3YjfBXZS86vVB68V