### PR TITLE
Bound requestCurrentState with a caller timeout and clear a stale nextUrl

### DIFF
--- a/src/serial.ts
+++ b/src/serial.ts
@@ -194,8 +194,12 @@ export class ImprovSerial extends EventTarget {
    * the Current State and if already provisioned,
    * the same response you would get if device provisioning
    * was successful (see below).
+   *
+   * A caller polling an intermittently-unresponsive device (e.g. one rebooting
+   * to switch network interfaces) can pass a timeout shorter than the default
+   * so each poll settles quickly.
    */
-  public async requestCurrentState() {
+  public async requestCurrentState(timeout?: number) {
     // Every device reports its state; a provisioned one also returns the next
     // URL. Attach the listener before sending, then wait for the state change;
     // the RPC promise is only used to surface a command error.
@@ -210,6 +214,7 @@ export class ImprovSerial extends EventTarget {
         rpcResult = this._sendRPCWithResponse(
           ImprovSerialRPCCommand.REQUEST_CURRENT_STATE,
           [],
+          timeout,
         );
         rpcResult.catch(reject);
       });
@@ -617,6 +622,12 @@ export class ImprovSerial extends EventTarget {
 
     if (packetType === ImprovSerialMessageType.CURRENT_STATE) {
       this.state = data[0];
+      if (this.state !== ImprovSerialCurrentState.PROVISIONED) {
+        // The URL from a successful provision is only valid while provisioned.
+        // A device that leaves that state (e.g. it detected an Ethernet link
+        // and rebooted with Wi-Fi disabled) must not keep advertising it.
+        this.nextUrl = undefined;
+      }
       this.dispatchEvent(
         new CustomEvent("state-changed", {
           detail: this.state,

--- a/test/serial.test.ts
+++ b/test/serial.test.ts
@@ -185,6 +185,54 @@ describe("ImprovSerial RPC serialization", () => {
     });
   });
 
+  it("times requestCurrentState out with the caller's timeout", async () => {
+    const client: any = newClient();
+    // Device never answers (e.g. it is rebooting to switch network
+    // interfaces). Without the forwarded timeout this would sit out the 30s
+    // default and blow the test timeout.
+    client._sendRPC = () => {};
+
+    await expect(client.requestCurrentState(50)).rejects.toThrow(
+      "Error fetching current state",
+    );
+    expect(client._rpcFeedback).toBeUndefined();
+  });
+
+  it("clears nextUrl when the device leaves the provisioned state", async () => {
+    const client: any = newClient();
+    client.state = ImprovSerialCurrentState.PROVISIONED;
+    client.nextUrl = "http://192.168.1.5";
+
+    // I M P R O V <VERSION> <TYPE> <LENGTH> <DATA> <CHECKSUM>
+    const currentStatePacket = (state: number) => {
+      const line = [
+        ..."IMPROV".split("").map((c) => c.charCodeAt(0)),
+        1, // version
+        1, // CURRENT_STATE
+        1, // length
+        state,
+      ];
+      line.push(line.reduce((sum, b) => sum + b, 0) & 0xff);
+      return line;
+    };
+
+    // Device reboots onto Ethernet with Wi-Fi disabled: provisioning stops
+    // and the old Wi-Fi URL is no longer valid.
+    client._handleIncomingPacket(
+      currentStatePacket(ImprovSerialCurrentState.STOPPED),
+    );
+    expect(client.state).toBe(ImprovSerialCurrentState.STOPPED);
+    expect(client.nextUrl).toBeUndefined();
+
+    // Staying provisioned keeps it.
+    client.state = ImprovSerialCurrentState.PROVISIONED;
+    client.nextUrl = "http://192.168.1.5";
+    client._handleIncomingPacket(
+      currentStatePacket(ImprovSerialCurrentState.PROVISIONED),
+    );
+    expect(client.nextUrl).toBe("http://192.168.1.5");
+  });
+
   it("catches a state change fired synchronously on send", async () => {
     const client: any = newClient();
     // An instant device that answers the moment the request goes out: the


### PR DESCRIPTION
## What

Two small correctness changes for consumers dealing with multi-interface devices (follow-up to #140):

1. **`requestCurrentState(timeout?)`** — expose the same optional timeout the other RPC helpers already take. A dashboard that polls a device's state (e.g. waiting for an Ethernet link to come up, or for a device that is mid-reboot switching network interfaces) needs each poll to settle quickly; today every `requestCurrentState` is held to the 30s `DEFAULT_RPC_TIMEOUT`, so one silent device turns a 2s poll cadence into ~35s ticks. No-arg callers (including `initialize()`) keep the existing default.

2. **Clear `nextUrl` when the device leaves `PROVISIONED`** — `nextUrl` is set by a successful `provision()` / provisioned `requestCurrentState`, but was never cleared. A device that later disables Wi-Fi (e.g. it detected an Ethernet link and rebooted onto it) kept advertising its dead Wi-Fi URL, which then shadowed the fresh URL it reports via `requestNetworkState`. The clearing lives in the CURRENT_STATE packet handler, so it covers both device-initiated state broadcasts and polled state requests; a successful re-provision still sets it afterward since the RPC result arrives after the state packet.

## Tests

Two added in the existing suite's style: a silent device rejects `requestCurrentState(50)` promptly (proving the timeout forwards — without it the test would hang on the 30s default), and a crafted CURRENT_STATE packet clears `nextUrl` on PROVISIONED → STOPPED while keeping it when the state stays PROVISIONED. All 10 tests pass.