### PR TITLE
Own the network state on the client with opt-in polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,21 @@ const improv = new ImprovSerial(port, console);
 
 improv.addEventListener("state-changed", console.log);
 improv.addEventListener("error-changed", console.log);
+improv.addEventListener("network-state-changed", console.log);
 
 await improv.initialize();
 
 improv.addEventListener("disconnect", console.log);
 
+// Optional: keep `improv.networkState` fresh (e.g. an Ethernet link coming
+// up). Stops itself for devices that don't support the command; also stopped
+// by `stopNetworkStatePolling()`, `close()`, and a disconnect.
+improv.startNetworkStatePolling();
+
 console.log({
   info: improv.info,
   nextUrl: improv.nextUrl,
+  networkState: improv.networkState,
 });
 
 await improv.provision(

--- a/README.md
+++ b/README.md
@@ -84,9 +84,7 @@ await improv.initialize();
 
 improv.addEventListener("disconnect", console.log);
 
-// Optional: keep `improv.networkState` fresh (e.g. an Ethernet link coming
-// up). Stops itself for devices that don't support the command; also stopped
-// by `stopNetworkStatePolling()`, `close()`, and a disconnect.
+// Optional: keeps `improv.networkState` fresh (e.g. an Ethernet link coming up).
 improv.startNetworkStatePolling();
 
 console.log({

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -61,13 +61,10 @@ const mergeSsids = (previous: Ssid[], latest: Ssid[]): Ssid[] => {
 /** Delay between Wi-Fi scans while subscribed. */
 const SCAN_INTERVAL = 3000;
 
-/** Delay between polls while network state polling is started. */
+/** Delay between network state polls. */
 const NETWORK_STATE_POLL_INTERVAL = 2500;
 
-/**
- * Timeout for each network state poll. Small so a busy device just costs a
- * skipped tick; the next poll recovers.
- */
+/** Per-poll timeout; small so a busy device only costs a tick — the next poll recovers. */
 const NETWORK_STATE_POLL_TIMEOUT = 500;
 
 /**
@@ -140,9 +137,8 @@ export class ImprovSerial extends EventTarget {
   private _networkState: NetworkState | null | undefined;
 
   /**
-   * Last known network state: `undefined` until a request succeeds, `null`
-   * once the device answers that it doesn't support the command. Assigning a
-   * change dispatches `network-state-changed`.
+   * Last known network state: `undefined` until a request succeeds, `null` once
+   * the device reports the command unsupported. Changes dispatch `network-state-changed`.
    */
   public get networkState(): NetworkState | null | undefined {
     return this._networkState;
@@ -164,9 +160,12 @@ export class ImprovSerial extends EventTarget {
     );
   }
 
-  private _networkStatePollActive = false;
+  // Identity of the active poll loop; a superseded loop sees a new token and exits.
+  private _networkStatePollToken?: object;
 
   private _networkStatePollWake?: () => void;
+
+  private _closed = false;
 
   private _reader?: ReadableStreamDefaultReader<Uint8Array>;
 
@@ -230,6 +229,7 @@ export class ImprovSerial extends EventTarget {
   }
 
   public async close() {
+    this._closed = true;
     this.stopNetworkStatePolling();
     if (!this._reader) {
       return;
@@ -481,8 +481,8 @@ export class ImprovSerial extends EventTarget {
         timeout,
       );
     } catch (err) {
-      if (this.error === ImprovSerialErrorState.UNKNOWN_RPC_COMMAND) {
-        // Definitive: the device answered that it doesn't know the command.
+      // Not `this.error`: a later error can overwrite it before this catch runs.
+      if (err === ERROR_MSGS[ImprovSerialErrorState.UNKNOWN_RPC_COMMAND]) {
         this.networkState = null;
       }
       throw err;
@@ -500,24 +500,25 @@ export class ImprovSerial extends EventTarget {
   }
 
   /**
-   * Poll the device's network state, keeping `networkState` fresh (each change
-   * dispatches `network-state-changed`). Starting is idempotent. Polling stops
-   * itself once the device reports it doesn't support the command; it is also
-   * stopped by `stopNetworkStatePolling()`, `close()`, and a disconnect.
-   *
-   * A failed poll (e.g. the device is busy or rebooting) keeps the last known
-   * state and simply retries on the next tick.
+   * Poll the device's network state, keeping `networkState` fresh. Idempotent;
+   * stopped by `stopNetworkStatePolling()`, `close()`, a disconnect, or the
+   * device reporting the command unsupported. A failed poll keeps the last
+   * known state and retries on the next tick.
    */
   public startNetworkStatePolling(
     interval: number = NETWORK_STATE_POLL_INTERVAL,
     timeout: number = NETWORK_STATE_POLL_TIMEOUT,
   ) {
-    if (this._networkStatePollActive || this.networkState === null) {
+    if (
+      this._networkStatePollToken ||
+      this.networkState === null ||
+      this._closed
+    ) {
       return;
     }
-    this._networkStatePollActive = true;
+    const token = (this._networkStatePollToken = {});
     (async () => {
-      while (this._networkStatePollActive) {
+      while (this._networkStatePollToken === token) {
         try {
           await this.requestNetworkState(timeout);
         } catch (err) {
@@ -526,7 +527,7 @@ export class ImprovSerial extends EventTarget {
           }
           this.logger.debug(`Failed to fetch network state: ${err}`);
         }
-        if (!this._networkStatePollActive) {
+        if (this._networkStatePollToken !== token) {
           break;
         }
         // Wait before the next poll, but wake immediately when stopped.
@@ -535,14 +536,18 @@ export class ImprovSerial extends EventTarget {
           setTimeout(resolve, interval);
         });
       }
-      this._networkStatePollActive = false;
-      this._networkStatePollWake = undefined;
+      // Skip cleanup when superseded: a newer loop owns these now.
+      if (this._networkStatePollToken === token) {
+        this._networkStatePollToken = undefined;
+        this._networkStatePollWake = undefined;
+      }
     })();
   }
 
   public stopNetworkStatePolling() {
-    this._networkStatePollActive = false;
+    this._networkStatePollToken = undefined;
     this._networkStatePollWake?.();
+    this._networkStatePollWake = undefined;
   }
 
   private _sendRPC(command: ImprovSerialRPCCommand, data: number[]) {
@@ -691,6 +696,7 @@ export class ImprovSerial extends EventTarget {
     }
 
     this.logger.debug("Finished read loop");
+    this._closed = true;
     this.stopNetworkStatePolling();
     this.dispatchEvent(new Event("disconnect"));
   }

--- a/src/serial.ts
+++ b/src/serial.ts
@@ -61,6 +61,15 @@ const mergeSsids = (previous: Ssid[], latest: Ssid[]): Ssid[] => {
 /** Delay between Wi-Fi scans while subscribed. */
 const SCAN_INTERVAL = 3000;
 
+/** Delay between polls while network state polling is started. */
+const NETWORK_STATE_POLL_INTERVAL = 2500;
+
+/**
+ * Timeout for each network state poll. Small so a busy device just costs a
+ * skipped tick; the next poll recovers.
+ */
+const NETWORK_STATE_POLL_TIMEOUT = 500;
+
 /**
  * Timeout for each scan while subscribed. Generous compared to a real scan
  * (a few seconds) so it only trips when the device stops responding, turning a
@@ -74,6 +83,16 @@ const SCAN_TIMEOUT = 30000;
  * command queue can't wedge on a device that stopped responding.
  */
 const DEFAULT_RPC_TIMEOUT = 30000;
+
+/** Whether two network states carry the same flags and URLs. */
+const networkStatesEqual = (a: NetworkState, b: NetworkState): boolean =>
+  a.online === b.online &&
+  a.supportsWifi === b.supportsWifi &&
+  a.supportsEthernet === b.supportsEthernet &&
+  a.supportsThread === b.supportsThread &&
+  a.supportsModem === b.supportsModem &&
+  a.urls.length === b.urls.length &&
+  a.urls.every((url, i) => url === b.urls[i]);
 
 /** Whether two (alphabetically sorted) SSID lists differ in any value. */
 const ssidsChanged = (a: Ssid[], b: Ssid[]): boolean => {
@@ -117,6 +136,37 @@ export class ImprovSerial extends EventTarget {
       new CustomEvent("error-changed", { detail: this._error }),
     );
   }
+
+  private _networkState: NetworkState | null | undefined;
+
+  /**
+   * Last known network state: `undefined` until a request succeeds, `null`
+   * once the device answers that it doesn't support the command. Assigning a
+   * change dispatches `network-state-changed`.
+   */
+  public get networkState(): NetworkState | null | undefined {
+    return this._networkState;
+  }
+
+  public set networkState(networkState: NetworkState | null | undefined) {
+    const previous = this._networkState;
+    this._networkState = networkState;
+    if (
+      previous === networkState ||
+      (previous != null &&
+        networkState != null &&
+        networkStatesEqual(previous, networkState))
+    ) {
+      return;
+    }
+    this.dispatchEvent(
+      new CustomEvent("network-state-changed", { detail: networkState }),
+    );
+  }
+
+  private _networkStatePollActive = false;
+
+  private _networkStatePollWake?: () => void;
 
   private _reader?: ReadableStreamDefaultReader<Uint8Array>;
 
@@ -180,6 +230,7 @@ export class ImprovSerial extends EventTarget {
   }
 
   public async close() {
+    this.stopNetworkStatePolling();
     if (!this._reader) {
       return;
     }
@@ -422,13 +473,22 @@ export class ImprovSerial extends EventTarget {
    * UNKNOWN_RPC_COMMAND, so this rejects with that error for such devices.
    */
   public async requestNetworkState(timeout?: number): Promise<NetworkState> {
-    const response = await this._sendRPCWithResponse(
-      ImprovSerialRPCCommand.REQUEST_NETWORK_STATE,
-      [],
-      timeout,
-    );
+    let response: string[];
+    try {
+      response = await this._sendRPCWithResponse(
+        ImprovSerialRPCCommand.REQUEST_NETWORK_STATE,
+        [],
+        timeout,
+      );
+    } catch (err) {
+      if (this.error === ImprovSerialErrorState.UNKNOWN_RPC_COMMAND) {
+        // Definitive: the device answered that it doesn't know the command.
+        this.networkState = null;
+      }
+      throw err;
+    }
     const flags = parseInt(response[0]);
-    return {
+    this.networkState = {
       online: (flags & ImprovNetworkFlag.IS_ONLINE) !== 0,
       supportsWifi: (flags & ImprovNetworkFlag.SUPPORTS_WIFI) !== 0,
       supportsEthernet: (flags & ImprovNetworkFlag.SUPPORTS_ETHERNET) !== 0,
@@ -436,6 +496,53 @@ export class ImprovSerial extends EventTarget {
       supportsModem: (flags & ImprovNetworkFlag.SUPPORTS_MODEM) !== 0,
       urls: response.slice(1),
     };
+    return this.networkState;
+  }
+
+  /**
+   * Poll the device's network state, keeping `networkState` fresh (each change
+   * dispatches `network-state-changed`). Starting is idempotent. Polling stops
+   * itself once the device reports it doesn't support the command; it is also
+   * stopped by `stopNetworkStatePolling()`, `close()`, and a disconnect.
+   *
+   * A failed poll (e.g. the device is busy or rebooting) keeps the last known
+   * state and simply retries on the next tick.
+   */
+  public startNetworkStatePolling(
+    interval: number = NETWORK_STATE_POLL_INTERVAL,
+    timeout: number = NETWORK_STATE_POLL_TIMEOUT,
+  ) {
+    if (this._networkStatePollActive || this.networkState === null) {
+      return;
+    }
+    this._networkStatePollActive = true;
+    (async () => {
+      while (this._networkStatePollActive) {
+        try {
+          await this.requestNetworkState(timeout);
+        } catch (err) {
+          if (this.networkState === null) {
+            break;
+          }
+          this.logger.debug(`Failed to fetch network state: ${err}`);
+        }
+        if (!this._networkStatePollActive) {
+          break;
+        }
+        // Wait before the next poll, but wake immediately when stopped.
+        await new Promise<void>((resolve) => {
+          this._networkStatePollWake = resolve;
+          setTimeout(resolve, interval);
+        });
+      }
+      this._networkStatePollActive = false;
+      this._networkStatePollWake = undefined;
+    })();
+  }
+
+  public stopNetworkStatePolling() {
+    this._networkStatePollActive = false;
+    this._networkStatePollWake?.();
   }
 
   private _sendRPC(command: ImprovSerialRPCCommand, data: number[]) {
@@ -584,6 +691,7 @@ export class ImprovSerial extends EventTarget {
     }
 
     this.logger.debug("Finished read loop");
+    this.stopNetworkStatePolling();
     this.dispatchEvent(new Event("disconnect"));
   }
 

--- a/test/serial.test.ts
+++ b/test/serial.test.ts
@@ -233,6 +233,110 @@ describe("ImprovSerial RPC serialization", () => {
     expect(client.nextUrl).toBe("http://192.168.1.5");
   });
 
+  it("stores the network state and dispatches network-state-changed only on change", async () => {
+    const client: any = newClient();
+    let result = ["6"]; // Wi-Fi + Ethernet, offline
+    client._sendRPC = () => {
+      setTimeout(() => {
+        const fb = client._rpcFeedback;
+        if (!fb) return;
+        fb.resolve(result);
+        client._rpcFeedback = undefined;
+      }, 5);
+    };
+    const events: any[] = [];
+    client.addEventListener("network-state-changed", (ev: CustomEvent) =>
+      events.push(ev.detail),
+    );
+
+    await client.requestNetworkState();
+    expect(client.networkState).toEqual({
+      online: false,
+      supportsWifi: true,
+      supportsEthernet: true,
+      supportsThread: false,
+      supportsModem: false,
+      urls: [],
+    });
+
+    await client.requestNetworkState(); // same answer: no new event
+
+    result = ["7", "http://192.168.1.10"]; // device came online
+    await client.requestNetworkState();
+
+    expect(events.length).toBe(2);
+    expect(events[1].online).toBe(true);
+    expect(events[1].urls).toEqual(["http://192.168.1.10"]);
+  });
+
+  it("marks network state unsupported on UNKNOWN_RPC_COMMAND and stops asking", async () => {
+    const client: any = newClient();
+    let sends = 0;
+    client._sendRPC = () => {
+      sends++;
+      setTimeout(
+        () => client._setError(ImprovSerialErrorState.UNKNOWN_RPC_COMMAND),
+        5,
+      );
+    };
+
+    await expect(client.requestNetworkState()).rejects.toBeDefined();
+    expect(client.networkState).toBeNull();
+
+    // Polling an unsupported device must not put anything on the wire.
+    client.startNetworkStatePolling(20);
+    await sleep(80);
+    expect(sends).toBe(1);
+  });
+
+  it("polls the network state until stopped", async () => {
+    const client: any = newClient();
+    let sends = 0;
+    client._sendRPC = () => {
+      sends++;
+      setTimeout(() => {
+        const fb = client._rpcFeedback;
+        if (!fb) return;
+        fb.resolve(["2"]);
+        client._rpcFeedback = undefined;
+      }, 5);
+    };
+
+    client.startNetworkStatePolling(20);
+    client.startNetworkStatePolling(20); // idempotent: must not start a second loop
+    await sleep(120);
+    expect(sends).toBeGreaterThanOrEqual(3);
+    expect(client.networkState?.supportsWifi).toBe(true);
+
+    client.stopNetworkStatePolling();
+    await sleep(40); // let an in-flight tick settle
+    const sendsAfterStop = sends;
+    await sleep(100); // a leaked second loop would keep sending here
+    expect(sends).toBe(sendsAfterStop);
+  });
+
+  it("stops network state polling on close", async () => {
+    const client: any = newClient();
+    let sends = 0;
+    client._sendRPC = () => {
+      sends++;
+      setTimeout(() => {
+        const fb = client._rpcFeedback;
+        if (!fb) return;
+        fb.resolve(["2"]);
+        client._rpcFeedback = undefined;
+      }, 5);
+    };
+
+    client.startNetworkStatePolling(20);
+    await sleep(60);
+    await client.close(); // no reader: returns right after stopping the poll
+    await sleep(40);
+    const sendsAfterClose = sends;
+    await sleep(100);
+    expect(sends).toBe(sendsAfterClose);
+  });
+
   it("catches a state change fired synchronously on send", async () => {
     const client: any = newClient();
     // An instant device that answers the moment the request goes out: the

--- a/test/serial.test.ts
+++ b/test/serial.test.ts
@@ -315,6 +315,63 @@ describe("ImprovSerial RPC serialization", () => {
     expect(sends).toBe(sendsAfterStop);
   });
 
+  it("keeps a single poll loop across a stop/start during an in-flight poll", async () => {
+    const client: any = newClient();
+    let sends = 0;
+    client._sendRPC = () => {
+      sends++;
+      // Slow answer so the stop/start lands while a poll is in flight.
+      setTimeout(() => {
+        const fb = client._rpcFeedback;
+        if (!fb) return;
+        fb.resolve(["2"]);
+        client._rpcFeedback = undefined;
+      }, 20);
+    };
+
+    client.startNetworkStatePolling(50);
+    await sleep(10); // first poll is now in flight
+    client.stopNetworkStatePolling();
+    client.startNetworkStatePolling(50); // restart before the old poll settles
+
+    // ~70ms per cycle fits ~5 polls here; a leaked second loop would double that.
+    await sleep(350);
+    expect(sends).toBeLessThanOrEqual(7);
+
+    client.stopNetworkStatePolling();
+    await sleep(40); // let an in-flight tick settle
+    const sendsAfterStop = sends;
+    await sleep(150); // a leaked loop would keep sending here
+    expect(sends).toBe(sendsAfterStop);
+  });
+
+  it("does not start polling on a closed client", async () => {
+    const client: any = newClient();
+    let sends = 0;
+    client._sendRPC = () => {
+      sends++;
+    };
+
+    await client.close(); // no reader: returns after marking the client closed
+    client.startNetworkStatePolling(20);
+    await sleep(80);
+    expect(sends).toBe(0);
+  });
+
+  it("classifies UNKNOWN_RPC_COMMAND even when a later error overwrites client.error", async () => {
+    const client: any = newClient();
+    client._sendRPC = () => {
+      setTimeout(() => {
+        client._setError(ImprovSerialErrorState.UNKNOWN_RPC_COMMAND);
+        // Lands before the rejection's catch (a microtask) can read it.
+        client.error = ImprovSerialErrorState.TIMEOUT;
+      }, 5);
+    };
+
+    await expect(client.requestNetworkState()).rejects.toBeDefined();
+    expect(client.networkState).toBeNull();
+  });
+
   it("stops network state polling on close", async () => {
     const client: any = newClient();
     let sends = 0;


### PR DESCRIPTION
## What

Follows up on review discussion in esphome/esp-web-tools#723: the client already owns `state`, `error`, and `nextUrl`, but network state (2.8.0's `requestNetworkState`) was left to the consumer to store and poll. This moves that ownership into `ImprovSerial`:

- New `networkState` property: `undefined` until a request succeeds, `null` once the device answers `UNKNOWN_RPC_COMMAND` (it doesn't support the command), otherwise the last received `NetworkState`. Any `requestNetworkState` call keeps it up to date, and changes dispatch a `network-state-changed` event — only on an actual change, so a steady poll doesn't spam listeners.
- Opt-in polling via `startNetworkStatePolling()` / `stopNetworkStatePolling()`. Idempotent start; a sleep-loop (like `subscribeSSIDs`) rather than `setInterval`, so polls serialize through the RPC queue and can't pile up. Polling stops itself for devices that don't support the command, and is also stopped by `close()` and a disconnect, so a discarded client can't keep hitting the wire. Failed polls (busy/rebooting device) keep the last known state and retry on the next tick.
- Defaults: 2.5s between polls, 500ms per-request timeout (both overridable), matching what esp-web-tools settled on in review.

## Testing

- Four new vitest cases: change-only event dispatch, `UNKNOWN_RPC_COMMAND` classification (and that polling then never touches the wire), poll loop start/idempotency/stop, and stop-on-close.
- `script/build` and `prettier --check src test` pass.
- Validated on real hardware through esp-web-tools (esphome/esp-web-tools#723 adapted to this API against a local build): a Wi-Fi-only device on current firmware (poll cadence, stop/resume across page changes and a console session, provisioning round-trips) and a pre-`0x07` legacy device (exactly one probe per client, immediate classification, no repeat traffic).

## Hardening (second commit, from an adversarial self-review)

- A stop/start while a poll was settling an in-flight request could leave two loops running (the liveness flag was shared); loops now carry an identity token and a superseded loop exits on its next check.
- `startNetworkStatePolling()` after `close()` (or after a disconnect) would start a loop nothing could ever stop; the client now refuses to start polling once closed.
- The `UNKNOWN_RPC_COMMAND` classification matched against `client.error`, which a later error can overwrite before the rejection's catch runs; it now matches the rejection itself.

Each fix has a regression test that fails against the previous commit (7 vitest cases for the feature in total).